### PR TITLE
Deephaven himan

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ vm.tf --> Create a Ubuntu VM
 
 # Notes
 
+# We have used custom image for this VM which has specific required packages installed. Once the VM was ready. We created an image using below command.
+
+gcloud compute images create deephaven    --source-disk=deeephaven-test-instance-1   --source-disk-zone=us-central1-a  --project himantej-development-test
+
 Check list of Google Cloud OS images --> https://cloud.google.com/compute/docs/images
 
 Create the Json file for authentication --> https://cloud.google.com/iam/docs/creating-managing-service-account-keys

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# deploy
+# Deploy Google Cloud Virtual Machines in a public-only single region with Terraform
+
+The script will install Apache web server on the virtual machines.
+
+network-firewall.tf --> Configure basic firewall for the network
+
+network.tf --> Define network, vpc, subnet, icmp firewall
+
+provider.tf --> Configure Google Cloud provider
+
+terraform.tfvars --> Defining variables 
+
+variables-auth.tf --> Application and authentication variables
+
+vm-output.tf --> Output of VM 
+
+vm.tf --> Create a Ubuntu VM with Apache web server
+
+# Notes
+
+Check list of Google Cloud OS images --> https://cloud.google.com/compute/docs/images
+
+Create the Json file for authentication --> https://cloud.google.com/iam/docs/creating-managing-service-account-keys
+
+Read the detailed post for this repo --> https://medium.com/@gmusumeci/getting-started-with-terraform-and-google-cloud-platform-gcp-e718017376d1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deploy Google Cloud Virtual Machines in a public-only single region with Terraform
 
-The script will install Apache web server on the virtual machines.
+The script will install deephaven application on the virtual machines.
 
 network-firewall.tf --> Configure basic firewall for the network
 
@@ -8,18 +8,16 @@ network.tf --> Define network, vpc, subnet, icmp firewall
 
 provider.tf --> Configure Google Cloud provider
 
-terraform.tfvars --> Defining variables 
+terraform.tfvars --> Defining variables
 
 variables-auth.tf --> Application and authentication variables
 
-vm-output.tf --> Output of VM 
+vm-output.tf --> Output of VM
 
-vm.tf --> Create a Ubuntu VM with Apache web server
+vm.tf --> Create a Ubuntu VM
 
 # Notes
 
 Check list of Google Cloud OS images --> https://cloud.google.com/compute/docs/images
 
 Create the Json file for authentication --> https://cloud.google.com/iam/docs/creating-managing-service-account-keys
-
-Read the detailed post for this repo --> https://medium.com/@gmusumeci/getting-started-with-terraform-and-google-cloud-platform-gcp-e718017376d1

--- a/network-firewall.tf
+++ b/network-firewall.tf
@@ -1,0 +1,23 @@
+# Basic Network Firewall Rules | network-firewall.tf
+
+# Allow 10000 for deephaven
+resource "google_compute_firewall" "allow-http" {
+  name    = "${var.app_name}-${var.app_environment}-fw-allow-http"
+  network = google_compute_network.vpc.name
+  allow {
+    protocol = "tcp"
+    ports    = ["10000"]
+  }
+  target_tags = ["deephaven"]
+}
+
+# allow ssh
+resource "google_compute_firewall" "allow-ssh" {
+  name    = "${var.app_name}-${var.app_environment}-fw-allow-ssh"
+  network = google_compute_network.vpc.name
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+  target_tags = ["ssh"]
+}

--- a/network-variables.tf
+++ b/network-variables.tf
@@ -1,0 +1,20 @@
+# network varibles | network-single-region.tf
+
+# define GCP region
+variable "gcp_region_1" {
+  type = string
+  description = "GCP region"
+}
+
+# define GCP zone
+variable "gcp_zone_1" {
+  type = string
+  description = "GCP zone"
+}
+
+# define Public subnet
+variable "public_subnet_cidr_1" {
+  type = string
+  description = "Public subnet CIDR 1"
+}
+

--- a/network.tf
+++ b/network.tf
@@ -1,0 +1,29 @@
+# Single region, public only network configuration | network.tf
+
+# create VPC
+resource "google_compute_network" "vpc" {
+  name                    = "${var.app_name}-${var.app_environment}-vpc"
+  auto_create_subnetworks = "false"
+  routing_mode            = "GLOBAL"
+}
+
+# create public subnet
+resource "google_compute_subnetwork" "public_subnet_1" {
+  name          = "${var.app_name}-${var.app_environment}-public-subnet-1"
+  ip_cidr_range = var.public_subnet_cidr_1
+  network       = google_compute_network.vpc.name
+  region        = var.gcp_region_1
+}
+
+# allow internal icmp (disable for better security)
+resource "google_compute_firewall" "allow-internal" {
+  name    = "${var.app_name}-${var.app_environment}-fw-allow-internal"
+  network = google_compute_network.vpc.name
+  allow {
+    protocol = "tcp"
+    ports    = ["1000"]
+  }
+  source_ranges = [
+    "${var.public_subnet_cidr_1}"
+  ]
+}

--- a/network.tf
+++ b/network.tf
@@ -21,7 +21,7 @@ resource "google_compute_firewall" "allow-internal" {
   network = google_compute_network.vpc.name
   allow {
     protocol = "tcp"
-    ports    = ["1000"]
+    ports    = ["10000"]
   }
   source_ranges = [
     "${var.public_subnet_cidr_1}"

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,12 @@
+# setup the GCP provider | provider.tf
+
+terraform {
+  required_version = ">= 0.12"
+}
+
+provider "google" {
+  project = var.app_project
+  credentials = file(var.gcp_auth_file)
+  region  = var.gcp_region_1
+  zone    = var.gcp_zone_1
+}

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,0 +1,401 @@
+{
+  "version": 4,
+  "terraform_version": "1.0.1",
+  "serial": 45,
+  "lineage": "7585c0c7-7f22-7f37-f690-622dfe42d3a5",
+  "outputs": {
+    "vm-external-ip": {
+      "value": "34.135.101.104",
+      "type": "string"
+    },
+    "vm-internal-ip": {
+      "value": "10.10.1.9",
+      "type": "string"
+    },
+    "vm-name": {
+      "value": "deephaven",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "data",
+      "type": "google_compute_image",
+      "name": "deephaven-image",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "archive_size_bytes": 3657082368,
+            "creation_timestamp": "2021-06-29T09:06:24.342-07:00",
+            "description": "",
+            "disk_size_gb": 60,
+            "family": "",
+            "filter": null,
+            "id": "projects/himantej-development-test/global/images/deephaven",
+            "image_encryption_key_sha256": "",
+            "image_id": "9047599369590078447",
+            "label_fingerprint": "42WmSpB8rSM=",
+            "labels": {},
+            "licenses": [
+              "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/licenses/centos-7"
+            ],
+            "name": "deephaven",
+            "project": "himantej-development-test",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/images/deephaven",
+            "source_disk": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/zones/us-central1-a/disks/deeephaven-test-instance-1",
+            "source_disk_encryption_key_sha256": "",
+            "source_disk_id": "8727431668163856981",
+            "source_image_id": "",
+            "status": "READY"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_compute_firewall",
+      "name": "allow-http",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "allow": [
+              {
+                "ports": [
+                  "10000"
+                ],
+                "protocol": "tcp"
+              }
+            ],
+            "creation_timestamp": "2021-06-28T10:22:25.680-07:00",
+            "deny": [],
+            "description": "",
+            "destination_ranges": [],
+            "direction": "INGRESS",
+            "disabled": false,
+            "enable_logging": null,
+            "id": "projects/himantej-development-test/global/firewalls/deephaven-test-fw-allow-http",
+            "log_config": [],
+            "name": "deephaven-test-fw-allow-http",
+            "network": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/networks/deephaven-test-vpc",
+            "priority": 1000,
+            "project": "himantej-development-test",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/firewalls/deephaven-test-fw-allow-http",
+            "source_ranges": [
+              "0.0.0.0/0"
+            ],
+            "source_service_accounts": [],
+            "source_tags": [],
+            "target_service_accounts": [],
+            "target_tags": [
+              "deephaven"
+            ],
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "google_compute_network.vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_compute_firewall",
+      "name": "allow-internal",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "allow": [
+              {
+                "ports": [
+                  "1000"
+                ],
+                "protocol": "tcp"
+              }
+            ],
+            "creation_timestamp": "2021-06-28T10:22:25.159-07:00",
+            "deny": [],
+            "description": "",
+            "destination_ranges": [],
+            "direction": "INGRESS",
+            "disabled": false,
+            "enable_logging": null,
+            "id": "projects/himantej-development-test/global/firewalls/deephaven-test-fw-allow-internal",
+            "log_config": [],
+            "name": "deephaven-test-fw-allow-internal",
+            "network": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/networks/deephaven-test-vpc",
+            "priority": 1000,
+            "project": "himantej-development-test",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/firewalls/deephaven-test-fw-allow-internal",
+            "source_ranges": [
+              "10.10.1.0/24"
+            ],
+            "source_service_accounts": [],
+            "source_tags": [],
+            "target_service_accounts": [],
+            "target_tags": [],
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "google_compute_network.vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_compute_firewall",
+      "name": "allow-ssh",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "allow": [
+              {
+                "ports": [
+                  "22"
+                ],
+                "protocol": "tcp"
+              }
+            ],
+            "creation_timestamp": "2021-06-28T10:22:25.664-07:00",
+            "deny": [],
+            "description": "",
+            "destination_ranges": [],
+            "direction": "INGRESS",
+            "disabled": false,
+            "enable_logging": null,
+            "id": "projects/himantej-development-test/global/firewalls/deephaven-test-fw-allow-ssh",
+            "log_config": [],
+            "name": "deephaven-test-fw-allow-ssh",
+            "network": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/networks/deephaven-test-vpc",
+            "priority": 1000,
+            "project": "himantej-development-test",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/firewalls/deephaven-test-fw-allow-ssh",
+            "source_ranges": [
+              "0.0.0.0/0"
+            ],
+            "source_service_accounts": [],
+            "source_tags": [],
+            "target_service_accounts": [],
+            "target_tags": [
+              "ssh"
+            ],
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "google_compute_network.vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_compute_instance",
+      "name": "vm_instance_public",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 6,
+          "attributes": {
+            "allow_stopping_for_update": null,
+            "attached_disk": [],
+            "boot_disk": [
+              {
+                "auto_delete": true,
+                "device_name": "persistent-disk-0",
+                "disk_encryption_key_raw": "",
+                "disk_encryption_key_sha256": "",
+                "initialize_params": [
+                  {
+                    "image": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/images/deephaven",
+                    "labels": {},
+                    "size": 60,
+                    "type": "pd-standard"
+                  }
+                ],
+                "kms_key_self_link": "",
+                "mode": "READ_WRITE",
+                "source": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/zones/us-central1-b/disks/deephaven"
+              }
+            ],
+            "can_ip_forward": false,
+            "confidential_instance_config": [],
+            "cpu_platform": "Intel Cascade Lake",
+            "current_status": "RUNNING",
+            "deletion_protection": false,
+            "description": "",
+            "desired_status": null,
+            "enable_display": false,
+            "guest_accelerator": [],
+            "hostname": "",
+            "id": "projects/himantej-development-test/zones/us-central1-b/instances/deephaven",
+            "instance_id": "1718828649285750503",
+            "label_fingerprint": "0VnEwNsh07U=",
+            "labels": {
+              "authorization": "103900000016063005"
+            },
+            "machine_type": "n2-standard-8",
+            "metadata": {
+              "authorization": "103900000016063005"
+            },
+            "metadata_fingerprint": "8l7ISfACBTk=",
+            "metadata_startup_script": "sudo touch /opt/startup.sh; sudo echo 'cd /opt; git clone https://git@github.com:deephaven/deephaven-core.git; cd deephaven-core; ./gradlew prepareCompose; docker-compose build; docker-compose -f /opt/deephaven-core/docker-compose.yml up' \u003e\u003e /opt/startup.sh; sudo chmod 755 /opt/startup.sh; bash /opt/startup.sh ",
+            "min_cpu_platform": "",
+            "name": "deephaven",
+            "network_interface": [
+              {
+                "access_config": [
+                  {
+                    "nat_ip": "34.135.101.104",
+                    "network_tier": "PREMIUM",
+                    "public_ptr_domain_name": ""
+                  }
+                ],
+                "alias_ip_range": [],
+                "name": "nic0",
+                "network": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/networks/deephaven-test-vpc",
+                "network_ip": "10.10.1.9",
+                "nic_type": "",
+                "subnetwork": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/regions/us-central1/subnetworks/deephaven-test-public-subnet-1",
+                "subnetwork_project": "himantej-development-test"
+              }
+            ],
+            "project": "himantej-development-test",
+            "reservation_affinity": [],
+            "resource_policies": [],
+            "scheduling": [
+              {
+                "automatic_restart": true,
+                "min_node_cpus": 0,
+                "node_affinities": [],
+                "on_host_maintenance": "MIGRATE",
+                "preemptible": false
+              }
+            ],
+            "scratch_disk": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/zones/us-central1-b/instances/deephaven",
+            "service_account": [],
+            "shielded_instance_config": [
+              {
+                "enable_integrity_monitoring": true,
+                "enable_secure_boot": false,
+                "enable_vtpm": true
+              }
+            ],
+            "tags": [
+              "deephaven",
+              "ssh"
+            ],
+            "tags_fingerprint": "DkRLALt-4Bw=",
+            "timeouts": null,
+            "zone": "us-central1-b"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiNiJ9",
+          "dependencies": [
+            "data.google_compute_image.deephaven-image",
+            "google_compute_network.vpc",
+            "google_compute_subnetwork.public_subnet_1"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_compute_network",
+      "name": "vpc",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "auto_create_subnetworks": false,
+            "delete_default_routes_on_create": false,
+            "description": "",
+            "gateway_ipv4": "",
+            "id": "projects/himantej-development-test/global/networks/deephaven-test-vpc",
+            "mtu": 0,
+            "name": "deephaven-test-vpc",
+            "project": "himantej-development-test",
+            "routing_mode": "GLOBAL",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/networks/deephaven-test-vpc",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH19"
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_compute_subnetwork",
+      "name": "public_subnet_1",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2021-06-28T10:22:27.115-07:00",
+            "description": "",
+            "fingerprint": null,
+            "gateway_address": "10.10.1.1",
+            "id": "projects/himantej-development-test/regions/us-central1/subnetworks/deephaven-test-public-subnet-1",
+            "ip_cidr_range": "10.10.1.0/24",
+            "log_config": [],
+            "name": "deephaven-test-public-subnet-1",
+            "network": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/networks/deephaven-test-vpc",
+            "private_ip_google_access": false,
+            "private_ipv6_google_access": "DISABLE_GOOGLE_ACCESS",
+            "project": "himantej-development-test",
+            "region": "us-central1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/regions/us-central1/subnetworks/deephaven-test-public-subnet-1",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "dependencies": [
+            "google_compute_network.vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "random_id",
+      "name": "instance_id",
+      "provider": "provider[\"registry.terraform.io/hashicorp/random\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "b64_std": "uA8/+w==",
+            "b64_url": "uA8_-w",
+            "byte_length": 4,
+            "dec": "3088007163",
+            "hex": "b80f3ffb",
+            "id": "uA8_-w",
+            "keepers": null,
+            "prefix": null
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    }
+  ]
+}

--- a/terraform.tfstate.backup
+++ b/terraform.tfstate.backup
@@ -1,0 +1,401 @@
+{
+  "version": 4,
+  "terraform_version": "1.0.1",
+  "serial": 44,
+  "lineage": "7585c0c7-7f22-7f37-f690-622dfe42d3a5",
+  "outputs": {
+    "vm-external-ip": {
+      "value": "34.135.101.104",
+      "type": "string"
+    },
+    "vm-internal-ip": {
+      "value": "10.10.1.9",
+      "type": "string"
+    },
+    "vm-name": {
+      "value": "deephaven",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "data",
+      "type": "google_compute_image",
+      "name": "deephaven-image",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "archive_size_bytes": 3657082368,
+            "creation_timestamp": "2021-06-29T09:06:24.342-07:00",
+            "description": "",
+            "disk_size_gb": 60,
+            "family": "",
+            "filter": null,
+            "id": "projects/himantej-development-test/global/images/deephaven",
+            "image_encryption_key_sha256": "",
+            "image_id": "9047599369590078447",
+            "label_fingerprint": "42WmSpB8rSM=",
+            "labels": {},
+            "licenses": [
+              "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/licenses/centos-7"
+            ],
+            "name": "deephaven",
+            "project": "himantej-development-test",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/images/deephaven",
+            "source_disk": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/zones/us-central1-a/disks/deeephaven-test-instance-1",
+            "source_disk_encryption_key_sha256": "",
+            "source_disk_id": "8727431668163856981",
+            "source_image_id": "",
+            "status": "READY"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_compute_firewall",
+      "name": "allow-http",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "allow": [
+              {
+                "ports": [
+                  "10000"
+                ],
+                "protocol": "tcp"
+              }
+            ],
+            "creation_timestamp": "2021-06-28T10:22:25.680-07:00",
+            "deny": [],
+            "description": "",
+            "destination_ranges": [],
+            "direction": "INGRESS",
+            "disabled": false,
+            "enable_logging": null,
+            "id": "projects/himantej-development-test/global/firewalls/deephaven-test-fw-allow-http",
+            "log_config": [],
+            "name": "deephaven-test-fw-allow-http",
+            "network": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/networks/deephaven-test-vpc",
+            "priority": 1000,
+            "project": "himantej-development-test",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/firewalls/deephaven-test-fw-allow-http",
+            "source_ranges": [
+              "0.0.0.0/0"
+            ],
+            "source_service_accounts": [],
+            "source_tags": [],
+            "target_service_accounts": [],
+            "target_tags": [
+              "deephaven"
+            ],
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "google_compute_network.vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_compute_firewall",
+      "name": "allow-internal",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "allow": [
+              {
+                "ports": [
+                  "1000"
+                ],
+                "protocol": "tcp"
+              }
+            ],
+            "creation_timestamp": "2021-06-28T10:22:25.159-07:00",
+            "deny": [],
+            "description": "",
+            "destination_ranges": [],
+            "direction": "INGRESS",
+            "disabled": false,
+            "enable_logging": null,
+            "id": "projects/himantej-development-test/global/firewalls/deephaven-test-fw-allow-internal",
+            "log_config": [],
+            "name": "deephaven-test-fw-allow-internal",
+            "network": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/networks/deephaven-test-vpc",
+            "priority": 1000,
+            "project": "himantej-development-test",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/firewalls/deephaven-test-fw-allow-internal",
+            "source_ranges": [
+              "10.10.1.0/24"
+            ],
+            "source_service_accounts": [],
+            "source_tags": [],
+            "target_service_accounts": [],
+            "target_tags": [],
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "google_compute_network.vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_compute_firewall",
+      "name": "allow-ssh",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "allow": [
+              {
+                "ports": [
+                  "22"
+                ],
+                "protocol": "tcp"
+              }
+            ],
+            "creation_timestamp": "2021-06-28T10:22:25.664-07:00",
+            "deny": [],
+            "description": "",
+            "destination_ranges": [],
+            "direction": "INGRESS",
+            "disabled": false,
+            "enable_logging": null,
+            "id": "projects/himantej-development-test/global/firewalls/deephaven-test-fw-allow-ssh",
+            "log_config": [],
+            "name": "deephaven-test-fw-allow-ssh",
+            "network": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/networks/deephaven-test-vpc",
+            "priority": 1000,
+            "project": "himantej-development-test",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/firewalls/deephaven-test-fw-allow-ssh",
+            "source_ranges": [
+              "0.0.0.0/0"
+            ],
+            "source_service_accounts": [],
+            "source_tags": [],
+            "target_service_accounts": [],
+            "target_tags": [
+              "ssh"
+            ],
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "google_compute_network.vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_compute_instance",
+      "name": "vm_instance_public",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 6,
+          "attributes": {
+            "allow_stopping_for_update": null,
+            "attached_disk": [],
+            "boot_disk": [
+              {
+                "auto_delete": true,
+                "device_name": "persistent-disk-0",
+                "disk_encryption_key_raw": "",
+                "disk_encryption_key_sha256": "",
+                "initialize_params": [
+                  {
+                    "image": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/images/deephaven",
+                    "labels": {},
+                    "size": 60,
+                    "type": "pd-standard"
+                  }
+                ],
+                "kms_key_self_link": "",
+                "mode": "READ_WRITE",
+                "source": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/zones/us-central1-b/disks/deephaven"
+              }
+            ],
+            "can_ip_forward": false,
+            "confidential_instance_config": [],
+            "cpu_platform": "Intel Cascade Lake",
+            "current_status": "RUNNING",
+            "deletion_protection": false,
+            "description": "",
+            "desired_status": null,
+            "enable_display": false,
+            "guest_accelerator": [],
+            "hostname": "",
+            "id": "projects/himantej-development-test/zones/us-central1-b/instances/deephaven",
+            "instance_id": "1718828649285750503",
+            "label_fingerprint": "0VnEwNsh07U=",
+            "labels": {
+              "authorization": "103900000016063005"
+            },
+            "machine_type": "n2-standard-8",
+            "metadata": {
+              "authorization": "103900000016063005"
+            },
+            "metadata_fingerprint": "8l7ISfACBTk=",
+            "metadata_startup_script": "sudo touch /opt/startup.sh; sudo echo 'cd /opt; git clone https://git@github.com:deephaven/deephaven-core.git; cd deephaven-core; ./gradlew prepareCompose; docker-compose build; docker-compose -f /opt/deephaven-core/docker-compose.yml up' \u003e\u003e /opt/startup.sh; sudo chmod 755 /opt/startup.sh; bash /opt/startup.sh ",
+            "min_cpu_platform": "",
+            "name": "deephaven",
+            "network_interface": [
+              {
+                "access_config": [
+                  {
+                    "nat_ip": "34.135.101.104",
+                    "network_tier": "PREMIUM",
+                    "public_ptr_domain_name": ""
+                  }
+                ],
+                "alias_ip_range": [],
+                "name": "nic0",
+                "network": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/networks/deephaven-test-vpc",
+                "network_ip": "10.10.1.9",
+                "nic_type": "",
+                "subnetwork": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/regions/us-central1/subnetworks/deephaven-test-public-subnet-1",
+                "subnetwork_project": "himantej-development-test"
+              }
+            ],
+            "project": "himantej-development-test",
+            "reservation_affinity": [],
+            "resource_policies": null,
+            "scheduling": [
+              {
+                "automatic_restart": true,
+                "min_node_cpus": 0,
+                "node_affinities": [],
+                "on_host_maintenance": "MIGRATE",
+                "preemptible": false
+              }
+            ],
+            "scratch_disk": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/zones/us-central1-b/instances/deephaven",
+            "service_account": [],
+            "shielded_instance_config": [
+              {
+                "enable_integrity_monitoring": true,
+                "enable_secure_boot": false,
+                "enable_vtpm": true
+              }
+            ],
+            "tags": [
+              "deephaven",
+              "ssh"
+            ],
+            "tags_fingerprint": "DkRLALt-4Bw=",
+            "timeouts": null,
+            "zone": "us-central1-b"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiNiJ9",
+          "dependencies": [
+            "data.google_compute_image.deephaven-image",
+            "google_compute_network.vpc",
+            "google_compute_subnetwork.public_subnet_1"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_compute_network",
+      "name": "vpc",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "auto_create_subnetworks": false,
+            "delete_default_routes_on_create": false,
+            "description": "",
+            "gateway_ipv4": "",
+            "id": "projects/himantej-development-test/global/networks/deephaven-test-vpc",
+            "mtu": 0,
+            "name": "deephaven-test-vpc",
+            "project": "himantej-development-test",
+            "routing_mode": "GLOBAL",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/networks/deephaven-test-vpc",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH19"
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_compute_subnetwork",
+      "name": "public_subnet_1",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2021-06-28T10:22:27.115-07:00",
+            "description": "",
+            "fingerprint": null,
+            "gateway_address": "10.10.1.1",
+            "id": "projects/himantej-development-test/regions/us-central1/subnetworks/deephaven-test-public-subnet-1",
+            "ip_cidr_range": "10.10.1.0/24",
+            "log_config": [],
+            "name": "deephaven-test-public-subnet-1",
+            "network": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/global/networks/deephaven-test-vpc",
+            "private_ip_google_access": false,
+            "private_ipv6_google_access": "DISABLE_GOOGLE_ACCESS",
+            "project": "himantej-development-test",
+            "region": "us-central1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/himantej-development-test/regions/us-central1/subnetworks/deephaven-test-public-subnet-1",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "dependencies": [
+            "google_compute_network.vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "random_id",
+      "name": "instance_id",
+      "provider": "provider[\"registry.terraform.io/hashicorp/random\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "b64_std": "uA8/+w==",
+            "b64_url": "uA8_-w",
+            "byte_length": 4,
+            "dec": "3088007163",
+            "hex": "b80f3ffb",
+            "id": "uA8_-w",
+            "keepers": null,
+            "prefix": null
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    }
+  ]
+}

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,0 +1,13 @@
+# Application Definition
+app_name        = "deephaven" #do NOT enter any spaces
+app_environment = "test"      # Dev, Test, Prod, etc
+# app_domain      = "kopicloud.com"
+app_project = "himantej-development-test"
+
+# GCP Settings
+gcp_region_1  = "us-central1"
+gcp_zone_1    = "us-central1-b"
+gcp_auth_file = "himantej-development-test-c197478b5cfc.json"
+
+# GCP Netwok
+public_subnet_cidr_1 = "10.10.1.0/24"

--- a/variables-auth.tf
+++ b/variables-auth.tf
@@ -1,0 +1,31 @@
+# Google Cloud connection & authentication and Application configuration | variables-auth.tf
+
+# GCP authentication file
+variable "gcp_auth_file" {
+  type        = string
+  description = "GCP authentication file"
+}
+
+# define GCP project name
+variable "app_project" {
+  type        = string
+  description = "GCP project name"
+}
+
+# define application name
+variable "app_name" {
+  type        = string
+  description = "Application name"
+}
+
+# # define application domain
+# variable "app_domain" {
+#   type = string
+#   description = "Application domain"
+# }
+
+# define application environment
+variable "app_environment" {
+  type        = string
+  description = "Application environment"
+}

--- a/vm-output.tf
+++ b/vm-output.tf
@@ -1,0 +1,13 @@
+# Virtual machine output | vm-output.tf
+
+output "vm-name" {
+  value = google_compute_instance.vm_instance_public.name
+}
+
+output "vm-external-ip" {
+  value = google_compute_instance.vm_instance_public.network_interface.0.access_config.0.nat_ip
+}
+
+output "vm-internal-ip" {
+  value = google_compute_instance.vm_instance_public.network_interface.0.network_ip
+}

--- a/vm.tf
+++ b/vm.tf
@@ -1,0 +1,43 @@
+# Create Google Cloud VM | vm.tf
+
+# Terraform plugin for creating random ids
+resource "random_id" "instance_id" {
+  byte_length = 4
+}
+
+data "google_compute_image" "deephaven-image" {
+  name = "deephaven"
+  # project = "himantej-development-test"
+  # could also use family = "family-name"
+}
+# Create VM #1
+resource "google_compute_instance" "vm_instance_public" {
+  name         = var.app_name
+  machine_type = "n2-standard-8"
+  zone         = var.gcp_zone_1
+  tags         = ["ssh", "deephaven"]
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.deephaven-image.self_link
+    }
+  }
+
+  metadata = {
+    authorization = "103900000016063005"
+  }
+
+  labels = {
+    authorization = "103900000016063005"
+  }
+
+  # metadata_startup_script = "sudo cd /opt/deephaven-core; sudo nohup docker-compose up &; sleep 5"
+  #metadata_startup_script = "sudo touch /opt/startup.sh; sudo echo 'cd /data; git clone https://git@github.com:deephaven/deephaven-core.git; cd deephaven-core; bash deephaven-core; docker-compose build; sudo echo 'docker-compose -f /opt/deephaven-core/docker-compose.yml' up >> /opt/startup.sh; sudo chmod 755 /opt/startup.sh; bash /opt/startup.sh "
+  metadata_startup_script = "sudo touch /opt/startup.sh; sudo echo 'cd /opt; git clone https://git@github.com:deephaven/deephaven-core.git; cd deephaven-core; ./gradlew prepareCompose; docker-compose build; docker-compose -f /opt/deephaven-core/docker-compose.yml up' >> /opt/startup.sh; sudo chmod 755 /opt/startup.sh; bash /opt/startup.sh "
+
+  network_interface {
+    network    = google_compute_network.vpc.name
+    subnetwork = google_compute_subnetwork.public_subnet_1.name
+    access_config {}
+  }
+}

--- a/vm.tf
+++ b/vm.tf
@@ -22,7 +22,7 @@ resource "google_compute_instance" "vm_instance_public" {
       image = data.google_compute_image.deephaven-image.self_link
     }
   }
-
+  #Labels to avoid alerts in cloudbakers can be removed later
   metadata = {
     authorization = "103900000016063005"
   }


### PR DESCRIPTION
Hey Devin 
Created a NEW PR, updated the port and Readme file.
 
443 port I will change later once we have set up with SSL ready. 

And about the terraform state files we can't add in git ignore as it has the current state of code and it should be in GIT else the state will be lost. I am not saving the state files in the GCS bucket as it will increase the GCP costing for end-user as well. 

About the metadata script, we can have another startup script file but it will need remote exec which will again involve RSA and Private keys. We should not make this more complicated in the view of the end-user product. 

Image details added in README.md file.